### PR TITLE
Use nmfs-style.css 

### DIFF
--- a/inst/Shiny/extra.css
+++ b/inst/Shiny/extra.css
@@ -1,0 +1,1 @@
+@import url("https://nmfs-fish-tools.github.io/nmfspalette/extra.css");

--- a/inst/Shiny/ui.r
+++ b/inst/Shiny/ui.r
@@ -1,6 +1,13 @@
 require(shiny)
 require(stockassessmentdictionary)
-ui <- fluidPage(theme = "nmfs-styles.css",
+ui <- fluidPage(
+  #theme = "nmfs-styles.css",
+  includeCSS("../../extra.css"),
+  # includeCSS("../../www/extra.css"),
+  # tags$head(
+  #   tags$style(HTML("
+  #     @import url('https://nmfs-fish-tools.github.io/nmfspalette/extra.css');"))
+  # ),
   uiOutput("choose_topic"),
   wellPanel(uiOutput("documentation"))
 )

--- a/inst/Shiny/ui.r
+++ b/inst/Shiny/ui.r
@@ -1,13 +1,8 @@
 require(shiny)
 require(stockassessmentdictionary)
 ui <- fluidPage(
-  #theme = "nmfs-styles.css",
-  includeCSS("extra.css"),
-  # includeCSS("../../www/extra.css"),
-  # tags$head(
-  #   tags$style(HTML("
-  #     @import url('https://nmfs-fish-tools.github.io/nmfspalette/extra.css');"))
-  # ),
+  # includeCSS("extra.css"),
+  includeCSS("nmfs-styles.css"),
   uiOutput("choose_topic"),
   wellPanel(uiOutput("documentation"))
 )

--- a/inst/Shiny/ui.r
+++ b/inst/Shiny/ui.r
@@ -2,7 +2,7 @@ require(shiny)
 require(stockassessmentdictionary)
 ui <- fluidPage(
   #theme = "nmfs-styles.css",
-  includeCSS("../../extra.css"),
+  includeCSS("extra.css"),
   # includeCSS("../../www/extra.css"),
   # tags$head(
   #   tags$style(HTML("


### PR DESCRIPTION
This PR addresses the Shiny App css issue. After using includeCSS() in the ui.r, the Shiny App page uses a NOAA themed website for the App.

Currently, the App uses the nmfs-style.css from the inst/Shiny. You can also use the inst/Shiny/extra.css if you want to import the css file from the nmfspalette package. 

To check the website locally, you can run following code:
```r
remotes::install_github("nmfs-fish-tools/data_dictionary", ref="feat-shiny-css")
library(shiny)
library(stockassessmentdictionary)
shiny_dd()
```